### PR TITLE
Fix titles have regexp meta characters

### DIFF
--- a/main.go
+++ b/main.go
@@ -53,7 +53,7 @@ func printContents(buf io.Writer, fd io.Reader, title string) {
 	isFenced := false
 	isBlank := false
 
-	r := regexp.MustCompile(fmt.Sprintf("^#* %s$", title))
+	r := regexp.MustCompile(fmt.Sprintf("^#* %s$", regexp.QuoteMeta(title)))
 
 	scanner := bufio.NewScanner(fd)
 	for scanner.Scan() {

--- a/main_test.go
+++ b/main_test.go
@@ -36,7 +36,7 @@ func TestPrintContents(t *testing.T) {
 	}{
 		{"# title", "# title\n\n" + "contents\n"},
 		{"# long title one", "# long title one\n\n" + "line one\nline two\n"},
-		{"# title has regexp meta chars $", "# title has regexp meta chars $\n\n" + "line\n"},
+		{"# title has regular expression meta chars $", "# title has regular expression meta chars $\n\n" + "line\n"},
 		{"# contents have blank lines", "# contents have blank lines\n\n" + "1st line\n\n2nd line\n"},
 		{"# same title", "# same title\n\n1st\n\n" + "# same title\n\n2nd\n\n" + "# same title\n\n3rd\n"},
 		{"## other heading level", "## other heading level\n\n" + "contents\n"},
@@ -68,7 +68,7 @@ func TestPrintFirstURL(t *testing.T) {
 	require.NoError(t, err)
 	defer fd.Close()
 
-	printFirstURL(&buf, fd, "url")
+	printFirstURL(&buf, fd, "URL")
 	assert.Equal(t, "http://github.com/yendo/fcs/\n", buf.String())
 }
 
@@ -129,7 +129,7 @@ func TestRun(t *testing.T) {
 		})
 
 		t.Run("with a arg", func(t *testing.T) {
-			os.Args = []string{"fcs-cli", "-u", "url"}
+			os.Args = []string{"fcs-cli", "-u", "URL"}
 
 			err := run(&buf)
 

--- a/main_test.go
+++ b/main_test.go
@@ -36,6 +36,7 @@ func TestPrintContents(t *testing.T) {
 	}{
 		{"# title", "# title\n\n" + "contents\n"},
 		{"# long title one", "# long title one\n\n" + "line one\nline two\n"},
+		{"# title has regexp meta chars $", "# title has regexp meta chars $\n\n" + "line\n"},
 		{"# contents have blank lines", "# contents have blank lines\n\n" + "1st line\n\n2nd line\n"},
 		{"# same title", "# same title\n\n1st\n\n" + "# same title\n\n2nd\n\n" + "# same title\n\n3rd\n"},
 		{"## other heading level", "## other heading level\n\n" + "contents\n"},

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -49,7 +49,7 @@ func TestCmd(t *testing.T) {
 		},
 		{
 			title:   "with url flag and an arg",
-			options: []string{"-u", "url"},
+			options: []string{"-u", "URL"},
 			err:     false,
 			stdout:  "http://github.com/yendo/fcs/\n",
 			stderr:  "",

--- a/test/test_fcnotes.md
+++ b/test/test_fcnotes.md
@@ -7,7 +7,7 @@ contents
 line one
 line two
 
-# title has regexp meta chars $
+# title has regular expression meta chars $
 
 line
 
@@ -58,7 +58,7 @@ The contents are ignored.
 # fenced heading
 ```
 
-# url
+# URL
 
 fcs: http://github.com/yendo/fcs/
 github: http://github.com/

--- a/test/test_fcnotes.md
+++ b/test/test_fcnotes.md
@@ -7,6 +7,10 @@ contents
 line one
 line two
 
+# title has regexp meta chars $
+
+line
+
 # contents have blank lines
 
 

--- a/test/test_helper.go
+++ b/test/test_helper.go
@@ -5,7 +5,7 @@ import "strings"
 func GetExpectedTitles() string {
 	titles := `title
 long title one
-title has regexp meta chars $
+title has regular expression meta chars $
 contents have blank lines
 same title
 other heading level
@@ -14,7 +14,7 @@ no contents
 no contents2
 no_space_title
 fenced code block
-url
+URL
 no blank line between title and contents
 `
 

--- a/test/test_helper.go
+++ b/test/test_helper.go
@@ -5,6 +5,7 @@ import "strings"
 func GetExpectedTitles() string {
 	titles := `title
 long title one
+title has regexp meta chars $
 contents have blank lines
 same title
 other heading level


### PR DESCRIPTION
fcs should prints the contents which title has regexp meta characters. (Close: #10 )